### PR TITLE
make paths relative to full couchdb url

### DIFF
--- a/couch-login.js
+++ b/couch-login.js
@@ -37,6 +37,9 @@ function CouchLogin (couch, tok) {
   else if (tok === 'basic')
     tok = BASIC
 
+  // ensure that couch url ends with a slash
+  couch.pathname = couch.pathname.replace(/\/?$/, '/');
+
   this.token = tok
   this.couch = url.format(couch)
   this.proxy = null
@@ -128,7 +131,7 @@ function makeReq (meth, body, f) { return function madeReq (p, d, cb) {
   if (!body) cb = d, d = null
 
   var h = {}
-  , u = url.resolve(this.couch, p)
+  , u = url.resolve(this.couch, p.replace(/^\//, ''))
   , req = { uri: u, headers: h, json: true, body: d, method: meth }
 
   if (this.token === BASIC) {
@@ -358,7 +361,7 @@ function logout (cb) {
   }
 
   var h = { cookie: 'AuthSession=' + this.token.AuthSession }
-  , u = url.resolve(this.couch, '/_session')
+  , u = url.resolve(this.couch, '_session')
   , req = { uri: u, headers: h, json: true }
 
   request.del(req, function (er, res, data) {


### PR DESCRIPTION
I have private npm registry behind a nginx which is doing encryption. Shortly speaking, nginx is proxying data from `https://my.example.com/couch/` to `http://my.example.com:12345/`.

This module fails to login there because it counts all urls (like '/_session') as relative to domain root and requests `https://my.example.com/_session/` instead of `https://my.example.com/couch/_session/`.
