### PR TITLE
Dont send body if empty

### DIFF
--- a/couch-login.js
+++ b/couch-login.js
@@ -138,7 +138,11 @@ function makeReq (meth, body, force) { return function madeReq (p, d, cb) {
 
   var h = {}
   , u = url.resolve(this.couch, p.replace(/^\//, ''))
-  , req = { uri: u, headers: h, json: true, body: d, method: meth }
+  , req = { uri: u, headers: h, json: true, method: meth }
+
+  if (body) {
+      req.body = body;
+  }
 
   if (this.token === BASIC) {
     if (!this.auth)

--- a/couch-login.js
+++ b/couch-login.js
@@ -138,11 +138,7 @@ function makeReq (meth, body, force) { return function madeReq (p, d, cb) {
 
   var h = {}
   , u = url.resolve(this.couch, p.replace(/^\//, ''))
-  , req = { uri: u, headers: h, json: true, method: meth }
-
-  if (body) {
-      req.body = body;
-  }
+  , req = { uri: u, headers: h,body:d||body, json: true, method: meth }
 
   if (this.token === BASIC) {
     if (!this.auth)


### PR DESCRIPTION
For some custom install of couchdb app, if body is empty, connection may be reset by peer.

Example with the npm registry couchapp.
