### PR TITLE
[api] login option for application/x-www-form-urlencoded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
   - '0.12'
   - 'iojs'
 before_install:
+  - chmod -R 0777 test/fixtures
   - npm install -g npm@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 node_js:
-  - '0.8'
   - '0.10'
   - '0.12'
   - 'iojs'
+  - '4'
+  - '5'
+  - '6'
 before_install:
   - chmod -R 0777 test/fixtures
   - npm install -g npm@latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # couch-login
 
+[![Build Status][ci-master]][travis-ci]
+
 This module lets you log into couchdb to get a session token, then make
 requests using that session.  It is basically just a thin wrapper around
 [@mikeal's request module](https://github.com/mikeal/request).
@@ -276,3 +278,6 @@ Additionall, if `req.session` or `res.session` is set, then it'll call
 
 This works really nice with
 [RedSess](https://github.com/isaacs/redsess).
+
+  [ci-master]: https://travis-ci.org/npm/couch-login.svg?branch=master
+  [travis-ci]: https://travis-ci.org/npm/couch-login

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "main": "couch-login.js",
   "scripts": {
+    "test:clean": "rm -f test/fixtures/_users.couch; rm -f test/fixtures/pid; rm -rf test/fixtures/.delete; rm -f test/fixtures/couch.log;  rm -f test/fixtures/couchdb.uri; exit 0;",
     "test": "tap test/*.js"
   },
   "dependencies": {

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -23,7 +23,10 @@ test('start couch as a zombie child', function (t) {
 
   try { fs.unlinkSync(logfile) } catch (er) {}
 
-  var child = spawn('couchdb', ['-a', conf], {
+  var inTravis = process.env.USER === "travis"
+  var command = inTravis ? "sudo" : "couchdb"
+  var args = inTravis ? ['-u', 'couchdb', '/usr/bin/couchdb', '-a', conf] : ['-a', conf]
+  var child = spawn(command, args, {
     detached: true,
     stdio: 'ignore',
     cwd: cwd

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,7 @@ var tap = require('tap')
 , CouchLogin = require('../couch-login.js')
 
 var auth = { name: 'testuser', password: 'test' }
+, formAuth = { name: 'testuser', password: 'test', form: true }
 , newAuth = { name: 'testuser', password: 'asdfasdf' }
 , couch = new CouchLogin('http://localhost:15985/')
 , u = '/_users/org.couchdb.user:' + auth.name
@@ -24,6 +25,25 @@ tap.test('login', function (t) {
     t.ifError(er)
     if (er) return t.end()
     okStatus(t, res)
+    t.deepEqual(data, { ok: true, name: 'testuser', roles: [] })
+    t.ok(couch.token)
+    t.deepEqual(couch.token,
+      { AuthSession: couch.token && couch.token.AuthSession,
+        version: '1',
+        expires: couch.token && couch.token.expires,
+        path: '/',
+        httponly: true })
+    t.ok(couch.token, 'has token')
+    t.end()
+  })
+})
+
+tap.test('login with application/x-www-form-urlencoded', function (t) {
+  couch.login(formAuth, function (er, res, data) {
+    t.ifError(er)
+    if (er) return t.end()
+    okStatus(t, res)
+    t.equal(res.req._headers['content-type'], 'application/x-www-form-urlencoded')
     t.deepEqual(data, { ok: true, name: 'testuser', roles: [] })
     t.ok(couch.token)
     t.deepEqual(couch.token,

--- a/test/fixtures/couch.ini
+++ b/test/fixtures/couch.ini
@@ -1,6 +1,7 @@
 [couchdb]
 database_dir = test/fixtures
 view_index_dir = test/fixtures
+uri_file = test/fixtures/couchdb.uri
 uuid = 3ec49bc6c314484cb21d684dc3fc778e
 
 [httpd]


### PR DESCRIPTION
Hello,

Cloudant requires form encoding for logins, but accepts JSON otherwise.  This patch enables the form encoding and is backwards-compatible.

I had some trouble getting the tests to run locally, but I don't see this causing any regressions.  Since Travis is setup for this repo I can make sure this PR passes all tests before merge.

Thanks!
